### PR TITLE
Fix unmatched parentheses in WebRTC CSP bypass

### DIFF
--- a/docs/ch2/10-csp-bypass.md
+++ b/docs/ch2/10-csp-bypass.md
@@ -299,7 +299,7 @@ var pc = new RTCPeerConnection({
       "credential":"."
     }]
 });
-pc.createOffer().then((sdp)=>pc.setLocalDescription(sdp);
+pc.createOffer().then((sdp)=>pc.setLocalDescription(sdp));
 ```
 
 目前也沒有方式可以限制它來傳輸資料，但未來也可能會有 [webrtc](https://w3c.github.io/webappsec-csp/#directive-webrtc) 這個規則。

--- a/i18n/en/docusaurus-plugin-content-docs/current/ch2/10-csp-bypass.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/ch2/10-csp-bypass.md
@@ -299,7 +299,7 @@ var pc = new RTCPeerConnection({
       "credential":"."
     }]
 });
-pc.createOffer().then((sdp)=>pc.setLocalDescription(sdp);
+pc.createOffer().then((sdp)=>pc.setLocalDescription(sdp));
 ```
 
 Currently, there is no way to restrict it from transmitting data, but in the future, there may be a rule called [webrtc](https://w3c.github.io/webappsec-csp/#directive-webrtc).


### PR DESCRIPTION
The WebRTC code to bypass CSP has an unmatched parentheses syntax error. This PR fixes the syntax error.